### PR TITLE
CloudFormation template to set up the prerequisites per your article

### DIFF
--- a/lambda-encryption-prerequisites.template
+++ b/lambda-encryption-prerequisites.template
@@ -1,0 +1,206 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+
+  "Description": "Sets up the pre-requisites for the CloudFormation encryption Lambda function",
+
+  "Resources": {
+    "LambdaEncryptionFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": { "Fn::Join": ["\n", [
+"import base64",
+"import uuid",
+"import httplib",
+"import urlparse",
+"import json",
+"import boto3",
+"",
+"",
+"def send_response(request, response, status=None, reason=None):",
+"    \"\"\" Send our response to the pre-signed URL supplied by CloudFormation",
+"",
+"    If no ResponseURL is found in the request, there is no place to send a",
+"    response. This may be the case if the supplied event was for testing.",
+"    \"\"\"",
+"",
+"    if status is not None:",
+"        response['Status'] = status",
+"",
+"    if reason is not None:",
+"        response['Reason'] = reason",
+"",
+"    if 'ResponseURL' in request and request['ResponseURL']:",
+"        url = urlparse.urlparse(request['ResponseURL'])",
+"        body = json.dumps(response)",
+"        https = httplib.HTTPSConnection(url.hostname)",
+"        https.request('PUT', url.path+'?'+url.query, body)",
+"",
+"    return response",
+"",
+"",
+"def lambda_handler(event, context):",
+"",
+"    response = {",
+"        'StackId': event['StackId'],",
+"        'RequestId': event['RequestId'],",
+"        'LogicalResourceId': event['LogicalResourceId'],",
+"        'Status': 'SUCCESS'",
+"    }",
+"",
+"    # PhysicalResourceId is meaningless here, but CloudFormation requires it",
+"    if 'PhysicalResourceId' in event:",
+"        response['PhysicalResourceId'] = event['PhysicalResourceId']",
+"    else:",
+"        response['PhysicalResourceId'] = str(uuid.uuid4())",
+"",
+"    # There is nothing to do for a delete request",
+"    if event['RequestType'] == 'Delete':",
+"        return send_response(event, response)",
+"",
+"    # Encrypt the value using AWS KMS and return the response",
+"    try:",
+"",
+"        for key in ['KeyId', 'PlainText']:",
+"            if key not in event['ResourceProperties'] or not event['ResourceProperties'][key]:",
+"                return send_response(",
+"                    event, response, status='FAILED',",
+"                    reason='The properties KeyId and PlainText must not be empty'",
+"                )",
+"",
+"        client = boto3.client('kms')",
+"        encrypted = client.encrypt(",
+"            KeyId=event['ResourceProperties']['KeyId'],",
+"            Plaintext=event['ResourceProperties']['PlainText']",
+"        )",
+"",
+"        response['Data'] = {",
+"            'CipherText': base64.b64encode(encrypted['CiphertextBlob'])",
+"        }",
+"        response['Reason'] = 'The value was successfully encrypted'",
+"",
+"    except Exception as E:",
+"        response['Status'] = 'FAILED'",
+"        response['Reason'] = 'Encryption Failed - See CloudWatch logs for the Lamba function backing the custom resource for details'",
+"",
+"    return send_response(event, response)"]]}},
+      "FunctionName": "cloud-formation-kms-resource",
+      "Description": "A custom CloudFormation resource that encrypts values using KMS",
+      "Runtime": "python2.7",
+      "Role": {"Fn::GetAtt":["LambdaFunctionRole","Arn"]},
+      "Handler": "index.lambda_handler"
+      }
+    },
+    "LambdaFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "lambda.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+              }
+            ]
+          },
+       "RoleName": "lambda-kms-for-cloudformation"
+      }
+   },
+   "KMSKey": {
+     "Type": "AWS::KMS::Key",
+     "Properties": {
+       "Description": "KMS key for cloudformation",
+       "Enabled": true,
+       "KeyPolicy": {
+  "Version": "2012-10-17",
+  "Id": "key-consolepolicy-2",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": {"Fn::Join": ["", ["arn:aws:iam::",{"Ref":"AWS::AccountId"},":root"]]}
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "Allow access for Key Administrators",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Create*",
+        "kms:Describe*",
+        "kms:Enable*",
+        "kms:List*",
+        "kms:Put*",
+        "kms:Update*",
+        "kms:Revoke*",
+        "kms:Disable*",
+        "kms:Get*",
+        "kms:Delete*",
+        "kms:ScheduleKeyDeletion",
+        "kms:CancelKeyDeletion"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Allow use of the key",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": {"Fn::GetAtt":["LambdaFunctionRole","Arn"]}
+      },
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Allow attachment of persistent resources",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": {"Fn::GetAtt":["LambdaFunctionRole","Arn"]}
+      },
+      "Action": [
+        "kms:CreateGrant",
+        "kms:ListGrants",
+        "kms:RevokeGrant"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Bool": {
+          "kms:GrantIsForAWSResource": "true"
+        }
+      }
+    }
+  ]
+}
+
+
+       }
+     
+
+     }
+   },
+  
+
+  "Outputs": {
+    "LambdaEncryptionFunction": {
+     "Value": {"Fn::GetAtt": ["LambdaEncryptionFunction","Arn"]},
+     "Export": { "Name": "LambdaEncryptionFunction" }
+    },
+    "KMSKeyId": {
+     "Value": {"Ref": "KMSKey"},
+     "Export": { "Name": "KMSKeyId" }
+    }
+
+ 
+  }
+}


### PR DESCRIPTION
Now that we can have cross-stack references, you can create this stack which will build the KMS key, lambda function, role etc.

Then in the stack(s) that needs to use this functionality, set the following properties on the EncryptedSuperSecretThing resource:
`"ServiceToken": {"Fn::ImportValue": "LambdaEncryptionFunction"},
"KeyId": {"Fn::ImportValue": "KMSKeyId"}`

Defining the function in-line in this template is gnarly (especially in JSON) but it makes for a very easy deployment.